### PR TITLE
Remove @/ path mapping documentation

### DIFF
--- a/BUILD_FIX_README.md
+++ b/BUILD_FIX_README.md
@@ -2,15 +2,15 @@
 
 ## ✅ ÇÖZÜLMÜş SORUNLAR
 
-### 1. **Ana Build Hatası - Path Mapping** ✅ DÜZELTILDI
-- **Sorun**: `tsconfig.json`'da `@/` path mapping tanımlı değildi
-- **Çözüm**: `tsconfig.json`'a `baseUrl` ve `paths` eklendi
-- **Sonuç**: `@/styles/globals.css` ve `@/components/...` import'ları artık çalışıyor
+### 1. **Ana Build Hatası - Path Mapping** ✅ DÜZELTİLDİ
+- **Sorun**: `@/` path mapping build sırasında hatalara yol açıyordu
+- **Çözüm**: `tsconfig.json`'dan `baseUrl` ve `paths` kaldırıldı
+- **Sonuç**: Tüm import'lar relative path kullanacak şekilde güncellendi
 
-### 2. **Import Tutarsızlığı** ✅ DÜZELTILDI  
-- **Sorun**: `index.tsx`'te relative import kullanılıyordu
-- **Çözüm**: Tüm import'lar `@/` syntax'ına çevrildi
-- **Sonuç**: Proje genelinde tutarlı import yapısı
+### 2. **Import Tutarsızlığı** ✅ DÜZELTİLDİ
+- **Sorun**: Farklı dosyalarda `@/` ve relative import karışık kullanılıyordu
+- **Çözüm**: `@/` path mapping kaldırıldığı için tüm dosyalar relative import kullanacak şekilde düzenlendi
+- **Sonuç**: Proje genelinde tutarlı ve basit import yapısı
 
 ## 🔧 EK OPTİMİZASYON ÖNERİLERİ
 
@@ -57,8 +57,8 @@ Eğer hala hata alırsanız:
 - Ana path mapping sorunu çözüldü
 - Proje artık build alabilmelidir
 - Font taşıma işlemini manuel yapmanız gerekiyor
-- Gelecekte import tutarlılığını koruyun (hep `@/` kullanın)
+- Gelecekte import tutarlılığını koruyun (relative path'ler kullanın)
 
 ---
 **Çözüm Tarihi:** 2025-07-04  
-**Ana Düzeltme:** tsconfig.json path mapping eklendi
+**Ana Düzeltme:** tsconfig.json'dan path mapping kaldırıldı

--- a/FIXES_SUMMARY.md
+++ b/FIXES_SUMMARY.md
@@ -8,9 +8,9 @@
 - ✅ Build artık ESLint hatalarında durmayacak
 
 ### **2. TypeScript Path Mapping Sorunu**
-- ✅ `tsconfig.json`'a `baseUrl` ve `paths` eklendi
-- ✅ `@/` import'ları artık çalışıyor
-- ✅ Module resolution sorunu çözüldü
+- ✅ `@/` path mapping build hatası veriyordu
+- ✅ `tsconfig.json`'dan `baseUrl` ve `paths` kaldırıldı
+- ✅ Tüm dosyalar relative import kullanacak şekilde güncellendi
 
 ### **3. Kullanılmayan Import'lar Temizlendi**
 - ✅ **Layout.tsx**: `WorkflowStep` ve `currentStep` kaldırıldı
@@ -39,7 +39,7 @@ npm run build
 ## 📋 **Düzeltilen Dosyalar Listesi**
 
 1. `next.config.mjs` - ESLint disable
-2. `tsconfig.json` - Path mapping
+2. `tsconfig.json` - Path mapping kaldırıldı
 3. `src/pages/index.tsx` - Import tutarlılığı
 4. `src/components/layout/Layout.tsx` - Unused imports
 5. `src/components/ui/ProcessingView.tsx` - Unused imports & dependencies
@@ -50,7 +50,7 @@ npm run build
 
 ## 🎉 **Sonuç**
 
-- **Ana build hatası**: ✅ ÇÖZÜLDİ (path mapping)
+- **Ana build hatası**: ✅ ÇÖZÜLDİ (path mapping kaldırıldı)
 - **ESLint engeli**: ✅ KALDIRILDI 
 - **Kullanılmayan kod**: ✅ TEMİZLENDİ
 - **Type safety**: ✅ İYİLEŞTİRİLDİ
@@ -61,4 +61,4 @@ Projeniz artık başarıyla build alabilecek durumda! 🎯
 ---
 **Çözüm Tarihi:** 2025-07-04  
 **Toplam Commit:** 8 adet düzeltme  
-**Ana Çözüm:** TypeScript path mapping + ESLint disable
+**Ana Çözüm:** tsconfig path mapping kaldırıldı + ESLint disable


### PR DESCRIPTION
## Summary
- clarify that path mapping was removed and all imports are relative
- update fix summaries so tsconfig no longer mentions `baseUrl` and `paths`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686971ddea6c832e8cf1d23c3a30179f